### PR TITLE
fix: scheduler

### DIFF
--- a/our_output/os_0_mlq_paging.out
+++ b/our_output/os_0_mlq_paging.out
@@ -1,11 +1,11 @@
 Time slot   0
 ld_routine
 	Loaded a process at input/proc/p0s, PID: 1 PRIO: 0
-	CPU 1: Dispatched process  1
+	CPU 0: Dispatched process  1
 Time slot   1
 	Loaded a process at input/proc/p1s, PID: 2 PRIO: 15
 Time slot   2
-	CPU 0: Dispatched process  2
+	CPU 1: Dispatched process  2
 Time slot   3
 Time slot   4
 Time slot   5
@@ -15,8 +15,8 @@ print_pgtbl: 0 - 512
 00000004: 80000000
 ---MEM DUMP---
 Time slot   6
-	CPU 1: Put process  1 to run queue
-	CPU 1: Dispatched process  1
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
 read region=1 offset=20 value=100
 print_pgtbl: 0 - 512
 00000000: 80000001
@@ -30,9 +30,9 @@ print_pgtbl: 0 - 512
 00000004: 80000000
 ---MEM DUMP---
 000000dc: 00000064
+	CPU 1: Put process  2 to run queue
+	CPU 1: Dispatched process  2
 Time slot   8
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
 read region=2 offset=20 value=102
 print_pgtbl: 0 - 512
 00000000: 80000001
@@ -49,9 +49,9 @@ print_pgtbl: 0 - 512
 00000014: 00000066
 000000dc: 00000064
 Time slot  10
-	CPU 1: Processed  1 has finished
-	CPU 1 stopped
+	CPU 0: Processed  1 has finished
+	CPU 0 stopped
 Time slot  11
 Time slot  12
-	CPU 0: Processed  2 has finished
-	CPU 0 stopped
+	CPU 1: Processed  2 has finished
+	CPU 1 stopped

--- a/our_output/os_1_mlq_paging.out
+++ b/our_output/os_1_mlq_paging.out
@@ -12,8 +12,8 @@ Time slot   3
 	Loaded a process at input/proc/m1s, PID: 3 PRIO: 15
 	CPU 2: Put process  2 to run queue
 	CPU 2: Dispatched process  3
+	CPU 1: Dispatched process  2
 Time slot   4
-	CPU 0: Dispatched process  2
 	CPU 3: Put process  1 to run queue
 	CPU 3: Dispatched process  1
 Time slot   5
@@ -23,12 +23,12 @@ print_pgtbl: 0 - 512
 00000000: 80000001
 00000004: 80000000
 ---MEM DUMP---
-Time slot   6
 	CPU 2: Put process  3 to run queue
 	CPU 2: Dispatched process  3
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-	CPU 1: Dispatched process  4
+	CPU 1: Put process  2 to run queue
+	CPU 1: Dispatched process  2
+Time slot   6
+	CPU 0: Dispatched process  4
 	CPU 3: Put process  1 to run queue
 	CPU 3: Dispatched process  1
 read region=1 offset=20 value=100
@@ -47,80 +47,55 @@ print_pgtbl: 0 - 512
 000000dc: 00000064
 	CPU 2: Put process  3 to run queue
 	CPU 2: Dispatched process  3
+	CPU 1: Put process  2 to run queue
+	CPU 1: Dispatched process  2
 Time slot   8
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-	CPU 1: Put process  4 to run queue
-	CPU 1: Dispatched process  5
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  5
 	Loaded a process at input/proc/p1s, PID: 6 PRIO: 15
 	CPU 3: Put process  1 to run queue
-	CPU 3: Dispatched process  4
+	CPU 3: Dispatched process  6
 Time slot   9
 	CPU 2: Put process  3 to run queue
-	CPU 2: Dispatched process  1
-read region=2 offset=20 value=102
-print_pgtbl: 0 - 512
-00000000: 80000001
-00000004: 80000000
----MEM DUMP---
-00000014: 00000066
-000000dc: 00000064
-	CPU 1: Put process  5 to run queue
-	CPU 1: Dispatched process  6
-Time slot  10
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  3
-	Loaded a process at input/proc/s0, PID: 7 PRIO: 38
-	CPU 3: Put process  4 to run queue
-	CPU 3: Dispatched process  7
-write region=3 offset=20 value=103
-print_pgtbl: 0 - 512
-00000000: 80000001
-00000004: 80000000
----MEM DUMP---
-00000014: 00000066
-000000dc: 00000064
-Time slot  11
-	CPU 2: Processed  1 has finished
-	CPU 2: Dispatched process  2
-	CPU 1: Put process  6 to run queue
-	CPU 1: Dispatched process  5
-Time slot  12
-	CPU 0: Processed  3 has finished
-	CPU 0: Dispatched process  4
-	CPU 3: Put process  7 to run queue
-	CPU 3: Dispatched process  6
-Time slot  13
-	CPU 2: Put process  2 to run queue
-	CPU 2: Dispatched process  7
-	CPU 1: Put process  5 to run queue
+	CPU 2: Dispatched process  3
+	CPU 1: Put process  2 to run queue
 	CPU 1: Dispatched process  2
-Time slot  14
-	CPU 0: Put process  4 to run queue
+Time slot  10
+	CPU 0: Put process  5 to run queue
+	CPU 0: Dispatched process  5
+	Loaded a process at input/proc/s0, PID: 7 PRIO: 38
+	CPU 3: Put process  6 to run queue
+	CPU 3: Dispatched process  6
+Time slot  11
+	CPU 2: Processed  3 has finished
+	CPU 2: Dispatched process  7
+	CPU 1: Put process  2 to run queue
+	CPU 1: Dispatched process  2
+Time slot  12
+	CPU 0: Put process  5 to run queue
 	CPU 0: Dispatched process  5
 write region=1 offset=20 value=102
 print_pgtbl: 0 - 512
 00000000: 80000005
 00000004: 80000004
 ---MEM DUMP---
-00000014: 00000067
+00000014: 00000066
 000000dc: 00000064
 	CPU 3: Put process  6 to run queue
-	CPU 3: Dispatched process  4
-Time slot  15
+	CPU 3: Dispatched process  6
+	CPU 1: Processed  2 has finished
+Time slot  13
 write region=2 offset=1000 value=1
 print_pgtbl: 0 - 512
 00000000: 80000005
+	CPU 1: Dispatched process  4
 00000004: 80000004
 ---MEM DUMP---
 00000014: 00000066
 000000dc: 00000064
-	CPU 1: Processed  2 has finished
-	CPU 1: Dispatched process  6
-	Loaded a process at input/proc/s1, PID: 8 PRIO: 0
+Time slot  14
 	CPU 2: Put process  7 to run queue
 	CPU 2: Dispatched process  7
-Time slot  16
 	CPU 0: Put process  5 to run queue
 	CPU 0: Dispatched process  5
 write region=0 offset=0 value=0
@@ -131,48 +106,76 @@ print_pgtbl: 0 - 512
 00000014: 00000066
 000000b0: 00000001
 000000dc: 00000064
-	CPU 3: Put process  4 to run queue
-	CPU 3: Dispatched process  4
-	CPU 1: Put process  6 to run queue
-	CPU 1: Dispatched process  8
-Time slot  17
+	CPU 3: Put process  6 to run queue
+	CPU 3: Dispatched process  6
+	CPU 1: Put process  4 to run queue
+	CPU 1: Dispatched process  4
+Time slot  15
 	CPU 0: Processed  5 has finished
-	CPU 0: Dispatched process  6
+	CPU 0: Dispatched process  1
+read region=2 offset=20 value=102
+print_pgtbl: 0 - 512
+00000000: 80000001
+00000004: 80000000
+---MEM DUMP---
+00000014: 00000066
+000000b0: 00000001
+000000dc: 00000064
+	Loaded a process at input/proc/s1, PID: 8 PRIO: 0
 	CPU 2: Put process  7 to run queue
-	CPU 2: Dispatched process  7
+	CPU 2: Dispatched process  8
+Time slot  16
+write region=3 offset=20 value=103
+print_pgtbl: 0 - 512
+00000000: 80000001
+00000004: 80000000
+---MEM DUMP---
+00000014: 00000066
+000000b0: 00000001
+000000dc: 00000064
+	CPU 3: Put process  6 to run queue
+	CPU 3: Dispatched process  6
+Time slot  17
+	CPU 1: Put process  4 to run queue
+	CPU 1: Dispatched process  7
+	CPU 0: Processed  1 has finished
+	CPU 0: Dispatched process  4
+	CPU 2: Put process  8 to run queue
+	CPU 2: Dispatched process  8
 Time slot  18
-	CPU 3: Put process  4 to run queue
-	CPU 3: Dispatched process  4
-	CPU 1: Put process  8 to run queue
-	CPU 1: Dispatched process  8
-Time slot  19
-	CPU 0: Put process  6 to run queue
-	CPU 0: Dispatched process  6
-	CPU 2: Put process  7 to run queue
-	CPU 2: Dispatched process  7
-Time slot  20
-	CPU 3: Processed  4 has finished
+	CPU 3: Processed  6 has finished
 	CPU 3 stopped
-	CPU 1: Put process  8 to run queue
-	CPU 1: Dispatched process  8
+	CPU 1: Put process  7 to run queue
+	CPU 1: Dispatched process  7
+Time slot  19
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  4
+	CPU 2: Put process  8 to run queue
+	CPU 2: Dispatched process  8
+Time slot  20
+	CPU 1: Put process  7 to run queue
 Time slot  21
-	CPU 0: Processed  6 has finished
-	CPU 0 stopped
-	CPU 2: Put process  7 to run queue
-	CPU 2: Dispatched process  7
+	CPU 1: Dispatched process  7
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  4
+	CPU 2: Put process  8 to run queue
+	CPU 2: Dispatched process  8
 Time slot  22
-Time slot  23
-	CPU 1: Put process  8 to run queue
-	CPU 1: Dispatched process  8
-	CPU 2: Put process  7 to run queue
-	CPU 2: Dispatched process  7
-Time slot  24
-	CPU 1: Processed  8 has finished
-	CPU 1 stopped
-Time slot  25
-Time slot  26
-	CPU 2: Put process  7 to run queue
-	CPU 2: Dispatched process  7
-Time slot  27
-	CPU 2: Processed  7 has finished
+	CPU 2: Processed  8 has finished
 	CPU 2 stopped
+	CPU 1: Put process  7 to run queue
+	CPU 1: Dispatched process  7
+Time slot  23
+	CPU 0: Processed  4 has finished
+	CPU 0 stopped
+Time slot  24
+Time slot  25
+	CPU 1: Put process  7 to run queue
+	CPU 1: Dispatched process  7
+Time slot  26
+Time slot  27
+	CPU 1: Put process  7 to run queue
+	CPU 1: Dispatched process  7
+Time slot  28
+	CPU 1: Processed  7 has finished
+	CPU 1 stopped

--- a/our_output/os_1_mlq_paging_small_1K.out
+++ b/our_output/os_1_mlq_paging_small_1K.out
@@ -1,102 +1,76 @@
 Time slot   0
 ld_routine
 	Loaded a process at input/proc/p0s, PID: 1 PRIO: 130
+	CPU 3: Dispatched process  1
 Time slot   1
-	CPU 2: Dispatched process  1
 	Loaded a process at input/proc/s3, PID: 2 PRIO: 39
-	CPU 3: Dispatched process  2
+	CPU 2: Dispatched process  2
 Time slot   2
-	CPU 2: Put process  1 to run queue
-	CPU 2: Dispatched process  1
+	CPU 3: Put process  1 to run queue
+	CPU 3: Dispatched process  1
 Time slot   3
 	Loaded a process at input/proc/m1s, PID: 3 PRIO: 15
-	CPU 3: Put process  2 to run queue
-	CPU 3: Dispatched process  3
+	CPU 2: Put process  2 to run queue
+	CPU 2: Dispatched process  3
 	CPU 1: Dispatched process  2
 Time slot   4
-	CPU 2: Put process  1 to run queue
-	CPU 2: Dispatched process  1
+	CPU 3: Put process  1 to run queue
+	CPU 3: Dispatched process  1
 Time slot   5
 	Loaded a process at input/proc/s2, PID: 4 PRIO: 120
-	CPU 3: Put process  3 to run queue
-	CPU 3: Dispatched process  3
 write region=1 offset=20 value=100
 print_pgtbl: 0 - 512
 00000000: 80000001
 00000004: 80000000
 ---MEM DUMP---
+	CPU 2: Put process  3 to run queue
+	CPU 2: Dispatched process  3
 	CPU 1: Put process  2 to run queue
 	CPU 1: Dispatched process  2
 Time slot   6
 	CPU 0: Dispatched process  4
 	Loaded a process at input/proc/m0s, PID: 5 PRIO: 120
-	CPU 2: Put process  1 to run queue
-	CPU 2: Dispatched process  5
-Time slot   7
-	CPU 3: Put process  3 to run queue
-	CPU 3: Dispatched process  1
-read region=1 offset=20 value=100
-print_pgtbl: 0 - 512
-00000000: 80000001
-00000004: 80000000
----MEM DUMP---
-000000dc: 00000064
-	CPU 1: Put process  2 to run queue
-	CPU 1: Dispatched process  3
-Time slot   8
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  2
-	Loaded a process at input/proc/p1s, PID: 6 PRIO: 15
-write region=2 offset=20 value=102
-print_pgtbl: 0 - 512
-00000000: 80000001
-00000004: 80000000
----MEM DUMP---
-000000dc: 00000064
-	CPU 2: Put process  5 to run queue
-	CPU 2: Dispatched process  5
-Time slot   9
 	CPU 3: Put process  1 to run queue
-	CPU 3: Dispatched process  4
-	CPU 1: Put process  3 to run queue
-	CPU 1: Dispatched process  1
-read region=2 offset=20 value=102
-print_pgtbl: 0 - 512
-00000000: 80000001
-00000004: 80000000
----MEM DUMP---
-00000014: 00000066
-000000dc: 00000064
-Time slot  10
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  6
-	Loaded a process at input/proc/s0, PID: 7 PRIO: 38
-	CPU 2: Put process  5 to run queue
+	CPU 3: Dispatched process  5
+Time slot   7
+	CPU 2: Put process  3 to run queue
 	CPU 2: Dispatched process  3
-write region=3 offset=20 value=103
-print_pgtbl: 0 - 512
-00000000: 80000001
-00000004: 80000000
----MEM DUMP---
-00000014: 00000066
-000000dc: 00000064
-Time slot  11
-	CPU 3: Put process  4 to run queue
-	CPU 3: Dispatched process  7
-	CPU 1: Processed  1 has finished
+Time slot   8
+	CPU 1: Put process  2 to run queue
 	CPU 1: Dispatched process  2
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  4
+	Loaded a process at input/proc/p1s, PID: 6 PRIO: 15
+	CPU 3: Put process  5 to run queue
+	CPU 3: Dispatched process  6
+Time slot   9
+	CPU 2: Put process  3 to run queue
+	CPU 2: Dispatched process  3
+Time slot  10
+	CPU 0: Put process  4 to run queue
+	CPU 1: Put process  2 to run queue
+	CPU 0: Dispatched process  5
+	CPU 1: Dispatched process  2
+	Loaded a process at input/proc/s0, PID: 7 PRIO: 38
+	CPU 3: Put process  6 to run queue
+	CPU 3: Dispatched process  6
+Time slot  11
+	CPU 2: Processed  3 has finished
+	CPU 2: Dispatched process  7
 Time slot  12
-	CPU 0: Put process  6 to run queue
+	CPU 0: Put process  5 to run queue
 	CPU 0: Dispatched process  5
 write region=1 offset=20 value=102
 print_pgtbl: 0 - 512
 00000000: 80000005
 00000004: 80000004
 ---MEM DUMP---
-00000014: 00000067
 000000dc: 00000064
-	CPU 2: Processed  3 has finished
-	CPU 2: Dispatched process  4
+	CPU 1: Put process  2 to run queue
+	CPU 1: Dispatched process  2
+	CPU 3: Put process  6 to run queue
+	CPU 3: Dispatched process  6
+	CPU 1: Processed  2 has finished
 Time slot  13
 write region=2 offset=1000 value=1
 print_pgtbl: 0 - 512
@@ -105,15 +79,12 @@ print_pgtbl: 0 - 512
 ---MEM DUMP---
 00000014: 00000066
 000000dc: 00000064
-	CPU 3: Put process  7 to run queue
-	CPU 3: Dispatched process  6
-	CPU 1: Put process  2 to run queue
-	CPU 1: Dispatched process  7
+	CPU 1: Dispatched process  4
+	CPU 2: Put process  7 to run queue
+	CPU 2: Dispatched process  7
 Time slot  14
 	CPU 0: Put process  5 to run queue
-	CPU 0: Dispatched process  2
-	CPU 2: Put process  4 to run queue
-	CPU 2: Dispatched process  5
+	CPU 0: Dispatched process  5
 write region=0 offset=0 value=0
 print_pgtbl: 0 - 512
 00000000: 80000005
@@ -122,57 +93,92 @@ print_pgtbl: 0 - 512
 00000014: 00000066
 000000b0: 00000001
 000000dc: 00000064
-Time slot  15
-	CPU 0: Processed  2 has finished
-	CPU 0: Dispatched process  4
-	Loaded a process at input/proc/s1, PID: 8 PRIO: 0
 	CPU 3: Put process  6 to run queue
-	CPU 3: Dispatched process  8
-	CPU 2: Processed  5 has finished
-	CPU 2: Dispatched process  6
-	CPU 1: Put process  7 to run queue
-	CPU 1: Dispatched process  7
+	CPU 3: Dispatched process  6
+	CPU 1: Put process  4 to run queue
+	CPU 1: Dispatched process  4
+Time slot  15
+	CPU 0: Processed  5 has finished
+	CPU 0: Dispatched process  1
+read region=1 offset=20 value=100
+print_pgtbl: 0 - 512
+00000000: 80000001
+00000004: 80000000
+---MEM DUMP---
+00000014: 00000066
+000000b0: 00000001
+000000dc: 00000064
+	Loaded a process at input/proc/s1, PID: 8 PRIO: 0
+	CPU 2: Put process  7 to run queue
+	CPU 2: Dispatched process  8
 Time slot  16
+write region=2 offset=20 value=102
+print_pgtbl: 0 - 512
+00000000: 80000001
+00000004: 80000000
+---MEM DUMP---
+00000014: 00000066
+000000b0: 00000001
+000000dc: 00000064
+	CPU 3: Put process  6 to run queue
+	CPU 3: Dispatched process  6
+	CPU 1: Put process  4 to run queue
 Time slot  17
-	CPU 0: Put process  4 to run queue
+	CPU 1: Dispatched process  7
+	CPU 0: Put process  1 to run queue
 	CPU 0: Dispatched process  4
-	CPU 3: Put process  8 to run queue
-	CPU 3: Dispatched process  8
-	CPU 2: Put process  6 to run queue
-	CPU 2: Dispatched process  6
+	CPU 2: Put process  8 to run queue
+	CPU 2: Dispatched process  8
+Time slot  18
+	CPU 3: Processed  6 has finished
+	CPU 3: Dispatched process  1
+read region=2 offset=20 value=102
+print_pgtbl: 0 - 512
+00000000: 80000001
+00000004: 80000000
+---MEM DUMP---
+00000014: 00000066
+000000b0: 00000001
+000000dc: 00000064
 	CPU 1: Put process  7 to run queue
 	CPU 1: Dispatched process  7
-Time slot  18
 Time slot  19
 	CPU 0: Put process  4 to run queue
 	CPU 0: Dispatched process  4
-	CPU 3: Put process  8 to run queue
-	CPU 3: Dispatched process  8
-	CPU 2: Put process  6 to run queue
-	CPU 2: Dispatched process  6
+write region=3 offset=20 value=103
+print_pgtbl: 0 - 512
+00000000: 80000001
+00000004: 80000000
+---MEM DUMP---
+00000014: 00000066
+000000b0: 00000001
+000000dc: 00000064
+	CPU 2: Put process  8 to run queue
+	CPU 2: Dispatched process  8
+Time slot  20
+	CPU 3: Processed  1 has finished
+	CPU 3 stopped
 	CPU 1: Put process  7 to run queue
 	CPU 1: Dispatched process  7
-Time slot  20
 Time slot  21
 	CPU 0: Processed  4 has finished
 	CPU 0 stopped
-	CPU 3: Put process  8 to run queue
-	CPU 3: Dispatched process  8
+	CPU 2: Put process  8 to run queue
+	CPU 2: Dispatched process  8
 Time slot  22
-	CPU 1: Put process  7 to run queue
-	CPU 1: Dispatched process  7
-	CPU 2: Processed  6 has finished
+	CPU 2: Processed  8 has finished
 	CPU 2 stopped
-	CPU 3: Processed  8 has finished
-	CPU 3 stopped
 Time slot  23
+	CPU 1: Put process  7 to run queue
+	CPU 1: Dispatched process  7
 Time slot  24
-	CPU 1: Put process  7 to run queue
-	CPU 1: Dispatched process  7
 Time slot  25
-Time slot  26
 	CPU 1: Put process  7 to run queue
 	CPU 1: Dispatched process  7
+Time slot  26
 Time slot  27
+	CPU 1: Put process  7 to run queue
+	CPU 1: Dispatched process  7
+Time slot  28
 	CPU 1: Processed  7 has finished
 	CPU 1 stopped

--- a/our_output/os_1_mlq_paging_small_4K.out
+++ b/our_output/os_1_mlq_paging_small_4K.out
@@ -4,14 +4,14 @@ ld_routine
 	CPU 3: Dispatched process  1
 Time slot   1
 	Loaded a process at input/proc/s3, PID: 2 PRIO: 39
-	CPU 2: Dispatched process  2
+	CPU 1: Dispatched process  2
 Time slot   2
 	CPU 3: Put process  1 to run queue
 	CPU 3: Dispatched process  1
 Time slot   3
 	Loaded a process at input/proc/m1s, PID: 3 PRIO: 15
-	CPU 2: Put process  2 to run queue
 	CPU 2: Dispatched process  3
+	CPU 1: Put process  2 to run queue
 	CPU 1: Dispatched process  2
 Time slot   4
 	CPU 3: Put process  1 to run queue
@@ -23,81 +23,56 @@ print_pgtbl: 0 - 512
 00000000: 80000001
 00000004: 80000000
 ---MEM DUMP---
-	CPU 2: Put process  3 to run queue
-	CPU 2: Dispatched process  3
 	CPU 1: Put process  2 to run queue
 	CPU 1: Dispatched process  2
 Time slot   6
 	CPU 0: Dispatched process  4
+	CPU 2: Put process  3 to run queue
+	CPU 2: Dispatched process  3
 	Loaded a process at input/proc/m0s, PID: 5 PRIO: 120
 	CPU 3: Put process  1 to run queue
 	CPU 3: Dispatched process  5
 Time slot   7
-	CPU 2: Put process  3 to run queue
-	CPU 2: Dispatched process  1
-read region=1 offset=20 value=100
-print_pgtbl: 0 - 512
-00000000: 80000001
-00000004: 80000000
----MEM DUMP---
-000000dc: 00000064
 	CPU 1: Put process  2 to run queue
-	CPU 1: Dispatched process  3
+	CPU 1: Dispatched process  2
 Time slot   8
 	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  2
+	CPU 0: Dispatched process  4
+	CPU 2: Put process  3 to run queue
+	CPU 2: Dispatched process  3
 	Loaded a process at input/proc/p1s, PID: 6 PRIO: 15
 	CPU 3: Put process  5 to run queue
-	CPU 3: Dispatched process  5
-write region=2 offset=20 value=102
-print_pgtbl: 0 - 512
-00000000: 80000001
-00000004: 80000000
----MEM DUMP---
-000000dc: 00000064
+	CPU 3: Dispatched process  6
 Time slot   9
-	CPU 2: Put process  1 to run queue
-	CPU 2: Dispatched process  4
-	CPU 1: Put process  3 to run queue
-	CPU 1: Dispatched process  1
-read region=2 offset=20 value=102
-print_pgtbl: 0 - 512
-00000000: 80000001
-00000004: 80000000
----MEM DUMP---
-00000014: 00000066
-000000dc: 00000064
+	CPU 2: Put process  3 to run queue
+	CPU 2: Dispatched process  3
+	CPU 1: Put process  2 to run queue
+	CPU 1: Dispatched process  2
 Time slot  10
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  6
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  5
 	Loaded a process at input/proc/s0, PID: 7 PRIO: 38
-	CPU 3: Put process  5 to run queue
-	CPU 3: Dispatched process  3
-write region=3 offset=20 value=103
-print_pgtbl: 0 - 512
-00000000: 80000001
-00000004: 80000000
----MEM DUMP---
-00000014: 00000066
-000000dc: 00000064
+	CPU 3: Put process  6 to run queue
+	CPU 3: Dispatched process  6
 Time slot  11
-	CPU 2: Put process  4 to run queue
+	CPU 2: Processed  3 has finished
 	CPU 2: Dispatched process  7
-	CPU 1: Processed  1 has finished
+	CPU 1: Put process  2 to run queue
 	CPU 1: Dispatched process  2
 Time slot  12
-	CPU 0: Put process  6 to run queue
+	CPU 0: Put process  5 to run queue
 	CPU 0: Dispatched process  5
 write region=1 offset=20 value=102
 print_pgtbl: 0 - 512
 00000000: 80000005
 00000004: 80000004
 ---MEM DUMP---
-00000014: 00000067
 000000dc: 00000064
-	CPU 3: Processed  3 has finished
-	CPU 3: Dispatched process  4
+	CPU 3: Put process  6 to run queue
+	CPU 3: Dispatched process  6
+	CPU 1: Processed  2 has finished
 Time slot  13
+	CPU 1: Dispatched process  4
 write region=2 offset=1000 value=1
 print_pgtbl: 0 - 512
 00000000: 80000005
@@ -106,14 +81,10 @@ print_pgtbl: 0 - 512
 00000014: 00000066
 000000dc: 00000064
 	CPU 2: Put process  7 to run queue
-	CPU 2: Dispatched process  6
-	CPU 1: Put process  2 to run queue
-	CPU 1: Dispatched process  7
+	CPU 2: Dispatched process  7
 Time slot  14
 	CPU 0: Put process  5 to run queue
-	CPU 0: Dispatched process  2
-	CPU 3: Put process  4 to run queue
-	CPU 3: Dispatched process  5
+	CPU 0: Dispatched process  5
 write region=0 offset=0 value=0
 print_pgtbl: 0 - 512
 00000000: 80000005
@@ -122,57 +93,92 @@ print_pgtbl: 0 - 512
 00000014: 00000066
 000000b0: 00000001
 000000dc: 00000064
+	CPU 3: Put process  6 to run queue
+	CPU 3: Dispatched process  6
+	CPU 1: Put process  4 to run queue
+	CPU 1: Dispatched process  4
 Time slot  15
-	CPU 0: Processed  2 has finished
-	CPU 0: Dispatched process  4
+	CPU 0: Processed  5 has finished
+	CPU 0: Dispatched process  1
+read region=1 offset=20 value=100
+print_pgtbl: 0 - 512
+00000000: 80000001
+00000004: 80000000
+---MEM DUMP---
+00000014: 00000066
+000000b0: 00000001
+000000dc: 00000064
 	Loaded a process at input/proc/s1, PID: 8 PRIO: 0
-	CPU 3: Processed  5 has finished
-	CPU 3: Dispatched process  8
-	CPU 2: Put process  6 to run queue
-	CPU 2: Dispatched process  6
-	CPU 1: Put process  7 to run queue
-	CPU 1: Dispatched process  7
+	CPU 2: Put process  7 to run queue
+	CPU 2: Dispatched process  8
 Time slot  16
+write region=2 offset=20 value=102
+print_pgtbl: 0 - 512
+00000000: 80000001
+00000004: 80000000
+---MEM DUMP---
+00000014: 00000066
+000000b0: 00000001
+000000dc: 00000064
+	CPU 3: Put process  6 to run queue
+	CPU 3: Dispatched process  6
+	CPU 1: Put process  4 to run queue
+	CPU 1: Dispatched process  7
 Time slot  17
-	CPU 0: Put process  4 to run queue
+	CPU 0: Put process  1 to run queue
 	CPU 0: Dispatched process  4
-	CPU 3: Put process  8 to run queue
-	CPU 3: Dispatched process  8
-	CPU 2: Put process  6 to run queue
-	CPU 2: Dispatched process  6
+	CPU 2: Put process  8 to run queue
+	CPU 2: Dispatched process  8
+Time slot  18
+	CPU 3: Processed  6 has finished
+	CPU 3: Dispatched process  1
+read region=2 offset=20 value=102
+print_pgtbl: 0 - 512
+00000000: 80000001
+00000004: 80000000
+---MEM DUMP---
+00000014: 00000066
+000000b0: 00000001
+000000dc: 00000064
 	CPU 1: Put process  7 to run queue
 	CPU 1: Dispatched process  7
-Time slot  18
 Time slot  19
 	CPU 0: Put process  4 to run queue
 	CPU 0: Dispatched process  4
-	CPU 3: Put process  8 to run queue
-	CPU 3: Dispatched process  8
-	CPU 2: Put process  6 to run queue
-	CPU 2: Dispatched process  6
+write region=3 offset=20 value=103
+print_pgtbl: 0 - 512
+00000000: 80000001
+00000004: 80000000
+---MEM DUMP---
+00000014: 00000066
+000000b0: 00000001
+000000dc: 00000064
+	CPU 2: Put process  8 to run queue
+	CPU 2: Dispatched process  8
+Time slot  20
+	CPU 3: Processed  1 has finished
+	CPU 3 stopped
 	CPU 1: Put process  7 to run queue
 	CPU 1: Dispatched process  7
-Time slot  20
 Time slot  21
 	CPU 0: Processed  4 has finished
 	CPU 0 stopped
-	CPU 3: Put process  8 to run queue
-	CPU 3: Dispatched process  8
-	CPU 2: Processed  6 has finished
+	CPU 2: Put process  8 to run queue
+	CPU 2: Dispatched process  8
 Time slot  22
+	CPU 2: Processed  8 has finished
 	CPU 2 stopped
-	CPU 1: Put process  7 to run queue
-	CPU 1: Dispatched process  7
-	CPU 3: Processed  8 has finished
-	CPU 3 stopped
 Time slot  23
+	CPU 1: Put process  7 to run queue
+	CPU 1: Dispatched process  7
 Time slot  24
-	CPU 1: Put process  7 to run queue
-	CPU 1: Dispatched process  7
 Time slot  25
-Time slot  26
 	CPU 1: Put process  7 to run queue
 	CPU 1: Dispatched process  7
+Time slot  26
 Time slot  27
+	CPU 1: Put process  7 to run queue
+	CPU 1: Dispatched process  7
+Time slot  28
 	CPU 1: Processed  7 has finished
 	CPU 1 stopped

--- a/our_output/os_1_singleCPU_mlq.out
+++ b/our_output/os_1_singleCPU_mlq.out
@@ -3,70 +3,109 @@ ld_routine
 	Loaded a process at input/proc/s4, PID: 1 PRIO: 4
 Time slot   1
 	CPU 0: Dispatched process  1
-	Loaded a process at input/proc/s3, PID: 2 PRIO: 3
 Time slot   2
+	Loaded a process at input/proc/s3, PID: 2 PRIO: 3
 Time slot   3
 	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
+	CPU 0: Dispatched process  2
 	Loaded a process at input/proc/m1s, PID: 3 PRIO: 2
 Time slot   4
 Time slot   5
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  3
 	Loaded a process at input/proc/s2, PID: 4 PRIO: 3
 Time slot   6
 Time slot   7
 	Loaded a process at input/proc/m0s, PID: 5 PRIO: 3
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
-Time slot   8
-	CPU 0: Processed  1 has finished
+	CPU 0: Put process  3 to run queue
 	CPU 0: Dispatched process  3
+Time slot   8
 	Loaded a process at input/proc/p1s, PID: 6 PRIO: 2
 Time slot   9
-Time slot  10
 	CPU 0: Put process  3 to run queue
 	CPU 0: Dispatched process  6
+Time slot  10
 	Loaded a process at input/proc/s0, PID: 7 PRIO: 1
 Time slot  11
+	CPU 0: Put process  6 to run queue
+	CPU 0: Dispatched process  7
 Time slot  12
-	CPU 0: Put process  6 to run queue
-	CPU 0: Dispatched process  3
 Time slot  13
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  7
 Time slot  14
-	CPU 0: Put process  3 to run queue
-	CPU 0: Dispatched process  6
 Time slot  15
-	Loaded a process at input/proc/s1, PID: 8 PRIO: 0
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  7
 Time slot  16
-	CPU 0: Put process  6 to run queue
-	CPU 0: Dispatched process  3
+	Loaded a process at input/proc/s1, PID: 8 PRIO: 0
 Time slot  17
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  8
 Time slot  18
-	CPU 0: Put process  3 to run queue
-	CPU 0: Dispatched process  6
 Time slot  19
+	CPU 0: Put process  8 to run queue
+	CPU 0: Dispatched process  8
 Time slot  20
-	CPU 0: Put process  6 to run queue
-	CPU 0: Dispatched process  3
 Time slot  21
+	CPU 0: Put process  8 to run queue
+	CPU 0: Dispatched process  8
 Time slot  22
-	CPU 0: Processed  3 has finished
-	CPU 0: Dispatched process  6
 Time slot  23
+	CPU 0: Put process  8 to run queue
+	CPU 0: Dispatched process  8
 Time slot  24
-	CPU 0: Put process  6 to run queue
-	CPU 0: Dispatched process  6
+	CPU 0: Processed  8 has finished
+	CPU 0: Dispatched process  7
 Time slot  25
 Time slot  26
-	CPU 0: Processed  6 has finished
-	CPU 0: Dispatched process  5
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  7
 Time slot  27
 Time slot  28
-	CPU 0: Put process  5 to run queue
-	CPU 0: Dispatched process  5
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  7
 Time slot  29
 Time slot  30
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  7
+Time slot  31
+Time slot  32
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  7
+Time slot  33
+	CPU 0: Processed  7 has finished
+	CPU 0: Dispatched process  3
+Time slot  34
+Time slot  35
+	CPU 0: Put process  3 to run queue
+	CPU 0: Dispatched process  6
+Time slot  36
+Time slot  37
+	CPU 0: Put process  6 to run queue
+	CPU 0: Dispatched process  3
+Time slot  38
+Time slot  39
+	CPU 0: Processed  3 has finished
+	CPU 0: Dispatched process  6
+Time slot  40
+Time slot  41
+	CPU 0: Put process  6 to run queue
+	CPU 0: Dispatched process  6
+Time slot  42
+Time slot  43
+	CPU 0: Put process  6 to run queue
+	CPU 0: Dispatched process  6
+Time slot  44
+Time slot  45
+	CPU 0: Processed  6 has finished
+	CPU 0: Dispatched process  5
+Time slot  46
+Time slot  47
+	CPU 0: Put process  5 to run queue
+	CPU 0: Dispatched process  5
+Time slot  48
+Time slot  49
 	CPU 0: Put process  5 to run queue
 	CPU 0: Dispatched process  5
 write region=1 offset=20 value=102
@@ -74,14 +113,14 @@ print_pgtbl: 0 - 512
 00000000: 80000003
 00000004: 80000002
 ---MEM DUMP---
-Time slot  31
+Time slot  50
 write region=2 offset=1000 value=1
 print_pgtbl: 0 - 512
 00000000: 80000003
 00000004: 80000002
 ---MEM DUMP---
 00000014: 00000066
-Time slot  32
+Time slot  51
 	CPU 0: Put process  5 to run queue
 	CPU 0: Dispatched process  5
 write region=0 offset=0 value=0
@@ -91,99 +130,60 @@ print_pgtbl: 0 - 512
 ---MEM DUMP---
 00000014: 00000066
 000000b0: 00000001
-Time slot  33
+Time slot  52
 	CPU 0: Processed  5 has finished
 	CPU 0: Dispatched process  2
-Time slot  34
-Time slot  35
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  36
-Time slot  37
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  38
-Time slot  39
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  40
-Time slot  41
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  42
-Time slot  43
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  44
-	CPU 0: Processed  2 has finished
-	CPU 0: Dispatched process  4
-Time slot  45
-Time slot  46
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  4
-Time slot  47
-Time slot  48
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  4
-Time slot  49
-Time slot  50
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  4
-Time slot  51
-Time slot  52
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  4
 Time slot  53
 Time slot  54
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  4
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  2
 Time slot  55
 Time slot  56
-	CPU 0: Processed  4 has finished
-	CPU 0: Dispatched process  8
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  2
 Time slot  57
 Time slot  58
-	CPU 0: Put process  8 to run queue
-	CPU 0: Dispatched process  8
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  2
 Time slot  59
 Time slot  60
-	CPU 0: Put process  8 to run queue
-	CPU 0: Dispatched process  8
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  2
 Time slot  61
+	CPU 0: Processed  2 has finished
+	CPU 0: Dispatched process  4
 Time slot  62
-	CPU 0: Put process  8 to run queue
-	CPU 0: Dispatched process  8
 Time slot  63
-	CPU 0: Processed  8 has finished
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  4
 Time slot  64
 Time slot  65
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  4
 Time slot  66
 Time slot  67
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  4
 Time slot  68
 Time slot  69
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  4
 Time slot  70
 Time slot  71
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  4
 Time slot  72
 Time slot  73
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Processed  4 has finished
+	CPU 0: Dispatched process  1
 Time slot  74
 Time slot  75
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
 Time slot  76
 Time slot  77
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
 Time slot  78
-	CPU 0: Processed  7 has finished
+	CPU 0: Processed  1 has finished
 	CPU 0 stopped

--- a/our_output/os_1_singleCPU_mlq_paging.out
+++ b/our_output/os_1_singleCPU_mlq_paging.out
@@ -1,72 +1,111 @@
 Time slot   0
 ld_routine
-	Loaded a process at input/proc/s4, PID: 1 PRIO: 4
 Time slot   1
+	Loaded a process at input/proc/s4, PID: 1 PRIO: 4
 	CPU 0: Dispatched process  1
-	Loaded a process at input/proc/s3, PID: 2 PRIO: 3
 Time slot   2
+	Loaded a process at input/proc/s3, PID: 2 PRIO: 3
 Time slot   3
 	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
+	CPU 0: Dispatched process  2
 	Loaded a process at input/proc/m1s, PID: 3 PRIO: 2
 Time slot   4
 Time slot   5
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  3
 	Loaded a process at input/proc/s2, PID: 4 PRIO: 3
 Time slot   6
 Time slot   7
-	Loaded a process at input/proc/m0s, PID: 5 PRIO: 3
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
-Time slot   8
-	CPU 0: Processed  1 has finished
+	CPU 0: Put process  3 to run queue
 	CPU 0: Dispatched process  3
-	Loaded a process at input/proc/p1s, PID: 6 PRIO: 2
+	Loaded a process at input/proc/m0s, PID: 5 PRIO: 3
+Time slot   8
 Time slot   9
-Time slot  10
+	Loaded a process at input/proc/p1s, PID: 6 PRIO: 2
 	CPU 0: Put process  3 to run queue
 	CPU 0: Dispatched process  6
+Time slot  10
 	Loaded a process at input/proc/s0, PID: 7 PRIO: 1
 Time slot  11
-Time slot  12
 	CPU 0: Put process  6 to run queue
-	CPU 0: Dispatched process  3
+	CPU 0: Dispatched process  7
+Time slot  12
 Time slot  13
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  7
 Time slot  14
-	CPU 0: Put process  3 to run queue
-	CPU 0: Dispatched process  6
 Time slot  15
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  7
 	Loaded a process at input/proc/s1, PID: 8 PRIO: 0
 Time slot  16
-	CPU 0: Put process  6 to run queue
-	CPU 0: Dispatched process  3
 Time slot  17
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  8
 Time slot  18
-	CPU 0: Put process  3 to run queue
-	CPU 0: Dispatched process  6
 Time slot  19
+	CPU 0: Put process  8 to run queue
+	CPU 0: Dispatched process  8
 Time slot  20
-	CPU 0: Put process  6 to run queue
-	CPU 0: Dispatched process  3
 Time slot  21
+	CPU 0: Put process  8 to run queue
+	CPU 0: Dispatched process  8
 Time slot  22
-	CPU 0: Processed  3 has finished
-	CPU 0: Dispatched process  6
 Time slot  23
+	CPU 0: Put process  8 to run queue
+	CPU 0: Dispatched process  8
 Time slot  24
-	CPU 0: Put process  6 to run queue
-	CPU 0: Dispatched process  6
+	CPU 0: Processed  8 has finished
+	CPU 0: Dispatched process  7
 Time slot  25
 Time slot  26
-	CPU 0: Processed  6 has finished
-	CPU 0: Dispatched process  5
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  7
 Time slot  27
 Time slot  28
-	CPU 0: Put process  5 to run queue
-	CPU 0: Dispatched process  5
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  7
 Time slot  29
 Time slot  30
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  7
+Time slot  31
+Time slot  32
+	CPU 0: Put process  7 to run queue
+	CPU 0: Dispatched process  7
+Time slot  33
+	CPU 0: Processed  7 has finished
+	CPU 0: Dispatched process  3
+Time slot  34
+Time slot  35
+	CPU 0: Put process  3 to run queue
+	CPU 0: Dispatched process  6
+Time slot  36
+Time slot  37
+	CPU 0: Put process  6 to run queue
+	CPU 0: Dispatched process  3
+Time slot  38
+Time slot  39
+	CPU 0: Processed  3 has finished
+	CPU 0: Dispatched process  6
+Time slot  40
+Time slot  41
+	CPU 0: Put process  6 to run queue
+	CPU 0: Dispatched process  6
+Time slot  42
+Time slot  43
+	CPU 0: Put process  6 to run queue
+	CPU 0: Dispatched process  6
+Time slot  44
+Time slot  45
+	CPU 0: Processed  6 has finished
+	CPU 0: Dispatched process  5
+Time slot  46
+Time slot  47
+	CPU 0: Put process  5 to run queue
+	CPU 0: Dispatched process  5
+Time slot  48
+Time slot  49
 	CPU 0: Put process  5 to run queue
 	CPU 0: Dispatched process  5
 write region=1 offset=20 value=102
@@ -74,14 +113,14 @@ print_pgtbl: 0 - 512
 00000000: 80000003
 00000004: 80000002
 ---MEM DUMP---
-Time slot  31
+Time slot  50
 write region=2 offset=1000 value=1
 print_pgtbl: 0 - 512
 00000000: 80000003
 00000004: 80000002
 ---MEM DUMP---
 00000014: 00000066
-Time slot  32
+Time slot  51
 	CPU 0: Put process  5 to run queue
 	CPU 0: Dispatched process  5
 write region=0 offset=0 value=0
@@ -91,99 +130,60 @@ print_pgtbl: 0 - 512
 ---MEM DUMP---
 00000014: 00000066
 000000b0: 00000001
-Time slot  33
+Time slot  52
 	CPU 0: Processed  5 has finished
 	CPU 0: Dispatched process  2
-Time slot  34
-Time slot  35
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  36
-Time slot  37
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  38
-Time slot  39
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  40
-Time slot  41
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  42
-Time slot  43
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  44
-	CPU 0: Processed  2 has finished
-	CPU 0: Dispatched process  4
-Time slot  45
-Time slot  46
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  4
-Time slot  47
-Time slot  48
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  4
-Time slot  49
-Time slot  50
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  4
-Time slot  51
-Time slot  52
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  4
 Time slot  53
 Time slot  54
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  4
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  2
 Time slot  55
 Time slot  56
-	CPU 0: Processed  4 has finished
-	CPU 0: Dispatched process  8
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  2
 Time slot  57
 Time slot  58
-	CPU 0: Put process  8 to run queue
-	CPU 0: Dispatched process  8
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  2
 Time slot  59
 Time slot  60
-	CPU 0: Put process  8 to run queue
-	CPU 0: Dispatched process  8
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  2
 Time slot  61
+	CPU 0: Processed  2 has finished
+	CPU 0: Dispatched process  4
 Time slot  62
-	CPU 0: Put process  8 to run queue
-	CPU 0: Dispatched process  8
 Time slot  63
-	CPU 0: Processed  8 has finished
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  4
 Time slot  64
 Time slot  65
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  4
 Time slot  66
 Time slot  67
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  4
 Time slot  68
 Time slot  69
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  4
 Time slot  70
 Time slot  71
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  4
 Time slot  72
 Time slot  73
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Processed  4 has finished
+	CPU 0: Dispatched process  1
 Time slot  74
 Time slot  75
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
 Time slot  76
 Time slot  77
-	CPU 0: Put process  7 to run queue
-	CPU 0: Dispatched process  7
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
 Time slot  78
-	CPU 0: Processed  7 has finished
+	CPU 0: Processed  1 has finished
 	CPU 0 stopped

--- a/our_output/sched.out
+++ b/our_output/sched.out
@@ -19,9 +19,9 @@ Time slot   7
 Time slot   8
 	CPU 0: Put process  3 to run queue
 	CPU 0: Dispatched process  3
+Time slot   9
 	CPU 1: Put process  2 to run queue
 	CPU 1: Dispatched process  2
-Time slot   9
 Time slot  10
 	CPU 1: Processed  2 has finished
 	CPU 1: Dispatched process  1

--- a/our_output/sched_0.out
+++ b/our_output/sched_0.out
@@ -1,67 +1,68 @@
 Time slot   0
 ld_routine
 	Loaded a process at input/proc/s0, PID: 1 PRIO: 4
+Time slot   1
 	CPU 0: Dispatched process  1
 	Loaded a process at input/proc/s0, PID: 2 PRIO: 0
-Time slot   1
 Time slot   2
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
 Time slot   3
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  2
 Time slot   4
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
 Time slot   5
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  2
 Time slot   6
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
 Time slot   7
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  2
 Time slot   8
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
 Time slot   9
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  2
 Time slot  10
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
 Time slot  11
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  2
 Time slot  12
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
 Time slot  13
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  2
 Time slot  14
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
 Time slot  15
-	CPU 0: Processed  1 has finished
+	CPU 0: Put process  2 to run queue
 	CPU 0: Dispatched process  2
 Time slot  16
 Time slot  17
 	CPU 0: Put process  2 to run queue
 	CPU 0: Dispatched process  2
 Time slot  18
-Time slot  19
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  20
-Time slot  21
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  22
-Time slot  23
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  24
-Time slot  25
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  26
-Time slot  27
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  28
-Time slot  29
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  2
-Time slot  30
 	CPU 0: Processed  2 has finished
+	CPU 0: Dispatched process  1
+Time slot  19
+Time slot  20
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
+Time slot  21
+Time slot  22
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
+Time slot  23
+Time slot  24
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
+Time slot  25
+Time slot  26
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
+Time slot  27
+Time slot  28
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
+Time slot  29
+Time slot  30
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
+Time slot  31
+	CPU 0: Processed  1 has finished
 	CPU 0 stopped

--- a/our_output/sched_1.out
+++ b/our_output/sched_1.out
@@ -7,125 +7,125 @@ Time slot   1
 	Loaded a process at input/proc/s0, PID: 3 PRIO: 0
 Time slot   2
 	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
+	CPU 0: Dispatched process  2
 	Loaded a process at input/proc/s0, PID: 4 PRIO: 0
 Time slot   3
 Time slot   4
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  3
 Time slot   5
 Time slot   6
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
+	CPU 0: Put process  3 to run queue
+	CPU 0: Dispatched process  4
 Time slot   7
 Time slot   8
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  2
 Time slot   9
 Time slot  10
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  3
 Time slot  11
 Time slot  12
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
+	CPU 0: Put process  3 to run queue
+	CPU 0: Dispatched process  4
 Time slot  13
 Time slot  14
-	CPU 0: Put process  1 to run queue
-	CPU 0: Dispatched process  1
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  2
 Time slot  15
-	CPU 0: Processed  1 has finished
-	CPU 0: Dispatched process  2
 Time slot  16
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  3
 Time slot  17
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  3
 Time slot  18
+	CPU 0: Put process  3 to run queue
+	CPU 0: Dispatched process  4
 Time slot  19
-	CPU 0: Put process  3 to run queue
-	CPU 0: Dispatched process  4
 Time slot  20
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  2
 Time slot  21
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  2
 Time slot  22
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  3
 Time slot  23
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  3
 Time slot  24
+	CPU 0: Put process  3 to run queue
+	CPU 0: Dispatched process  4
 Time slot  25
-	CPU 0: Put process  3 to run queue
-	CPU 0: Dispatched process  4
 Time slot  26
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  2
 Time slot  27
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  2
 Time slot  28
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  3
 Time slot  29
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  3
 Time slot  30
+	CPU 0: Put process  3 to run queue
+	CPU 0: Dispatched process  4
 Time slot  31
-	CPU 0: Put process  3 to run queue
-	CPU 0: Dispatched process  4
 Time slot  32
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  2
 Time slot  33
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  2
 Time slot  34
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  3
 Time slot  35
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  3
 Time slot  36
+	CPU 0: Put process  3 to run queue
+	CPU 0: Dispatched process  4
 Time slot  37
-	CPU 0: Put process  3 to run queue
-	CPU 0: Dispatched process  4
 Time slot  38
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  2
 Time slot  39
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  2
 Time slot  40
+	CPU 0: Put process  2 to run queue
+	CPU 0: Dispatched process  3
 Time slot  41
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  3
 Time slot  42
+	CPU 0: Put process  3 to run queue
+	CPU 0: Dispatched process  4
 Time slot  43
-	CPU 0: Put process  3 to run queue
-	CPU 0: Dispatched process  4
 Time slot  44
+	CPU 0: Put process  4 to run queue
+	CPU 0: Dispatched process  2
 Time slot  45
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  2
-Time slot  46
-Time slot  47
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  3
-Time slot  48
-Time slot  49
-	CPU 0: Put process  3 to run queue
-	CPU 0: Dispatched process  4
-Time slot  50
-Time slot  51
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  2
-Time slot  52
-Time slot  53
-	CPU 0: Put process  2 to run queue
-	CPU 0: Dispatched process  3
-Time slot  54
-Time slot  55
-	CPU 0: Put process  3 to run queue
-	CPU 0: Dispatched process  4
-Time slot  56
-Time slot  57
-	CPU 0: Put process  4 to run queue
-	CPU 0: Dispatched process  2
-Time slot  58
 	CPU 0: Processed  2 has finished
 	CPU 0: Dispatched process  3
-Time slot  59
+Time slot  46
 	CPU 0: Processed  3 has finished
 	CPU 0: Dispatched process  4
-Time slot  60
+Time slot  47
 	CPU 0: Processed  4 has finished
+	CPU 0: Dispatched process  1
+Time slot  48
+Time slot  49
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
+Time slot  50
+Time slot  51
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
+Time slot  52
+Time slot  53
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
+Time slot  54
+Time slot  55
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
+Time slot  56
+Time slot  57
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
+Time slot  58
+Time slot  59
+	CPU 0: Put process  1 to run queue
+	CPU 0: Dispatched process  1
+Time slot  60
+	CPU 0: Processed  1 has finished
 	CPU 0 stopped

--- a/src/os.c
+++ b/src/os.c
@@ -148,7 +148,7 @@ static void read_config(const char *path) {
 #ifdef MM_PAGING
 	int sit;
 #ifdef MM_FIXED_MEMSZ
-	/* We provide here a back compatible with legacy OS simulatiom config file
+	/* We provide here a back compatible with legacy OS simulation config file
 	 * In which, it have no addition config line for Mema, keep only one line
 	 * for legacy info
 	 *  [time slice] [N = Number of CPU] [M = Number of Processes to be run]


### PR DESCRIPTION
Fix the scheduler accordingly
Idea: 
- Get the process with higher priority
- If none, check if current priority still has dedicated slots.
- If not, attempt to get the greatest priority process available
- If the only available process is current priority, use it